### PR TITLE
feat: Add Banner molecule component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## [Unreleased] - 2026-02-18
+## [Unreleased] - 2026-02-20
 
 ### Added
 
+- `Banner` molecule (contextual banner for informational messages with optional actions) + `BannerStyle` and presets (`.info()`, `.warning()`, `.success()`, `.error()`).
 - Standardized SwiftDoc for public APIs: `Popup`, `PopupStyle`, `BackgroundStatusBarStyle` and public modifiers (`backgroundStatusBar`, `bannerAndPopup`).
 - `ActionButton` atom (style-driven, size variants, icon-only and custom label initializers) + `ActionButtonStyle` presets including `.primaryCyan` and `.iconCircle`.
 - `AvatarImage` atom (circular avatars showing either an image or the first letter of a name) with fallback-initial logic, plus `AvatarImageStyle` and presets (`.default`, `.small`, `.large`, `.bordered`).

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,6 +1,17 @@
 # Journal
 
+## 2026-02-20 — Banner molecule for contextual messages
+
+- Added `Banner` molecule supporting informational messages with optional actions.
+- Created `BannerStyle` contract with presets (`.info()`, `.warning()`, `.success()`, `.error()`).
+- Component supports optional subtitle and custom action content via ViewBuilder.
+- Added comprehensive previews demonstrating all style variants.
+- Updated `README.md` and `CHANGELOG.md`.
+
+Rationale: Banners provide a flexible, style-driven way to display contextual feedback (info, warnings, success, errors) with optional action buttons. Following UILibrary's architecture, all visual tokens are injected via `BannerStyle`, making the component brand-agnostic and reusable across multiple apps. The molecule layer is appropriate as it combines icon, text, and optional action content into a cohesive UI pattern.
+
 ## 2026-02-20 — Centralize onboarding ProgressBar into UILibrary
+
 - Added `ProgressBar` atom supporting determinate, indeterminate and segmented (step) variants.
 - Introduced `ProgressBarStyle` with presets and step/segment presentation tokens.
 - Added previews and compile-time unit tests.
@@ -9,6 +20,7 @@
 Rationale: extracted onboarding-specific progress UI into a reusable, style-driven atom to remove duplication and follow UILibrary's style-injection and Atomic Design rules.
 
 ## 2026-02-20 — AvatarImage atom
+
 - Created `AvatarImage` atom with optional `image` and name-based initial fallback.
 - Added `AvatarImageStyle` contract, presets (`.default`, `.small`, `.large`, `.bordered`), and comprehensive previews.
 - Updated tests with compile-time smoke and style assertions.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Maintain an updated list of public components.
 
 ## Molecules
 
-// (No public Molecules implemented yet)
+- **Banner** – Contextual banner for displaying informational messages with optional actions. Supports info, warning, success, and error styles. API: `Banner(title: String, subtitle: String? = nil, style: BannerStyle = .info(), actionContent: () -> ActionContent)`
 
 ## Organisms
 

--- a/Sources/UILibrary/Components/Molecules/Banner/Banner.swift
+++ b/Sources/UILibrary/Components/Molecules/Banner/Banner.swift
@@ -1,0 +1,159 @@
+//
+//  Banner.swift
+//  UILibrary
+//
+//  Created by Marco La Gala on 20/02/26.
+//
+
+import SwiftUI
+
+/// A contextual banner for displaying informational messages with optional actions.
+///
+/// **Layer:** Molecule
+///
+/// **Responsibility:**
+/// Purely presentational banner with icon, title, optional subtitle, and optional action content.
+/// All visual tokens are provided via `BannerStyle`.
+///
+/// **Usage:**
+/// Inject a `BannerStyle` to control colors, spacing, and appearance.
+///
+/// Example:
+/// ```swift
+/// // Simple banner
+/// Banner(
+///     title: "Success!",
+///     subtitle: "Your changes have been saved.",
+///     style: .success()
+/// )
+///
+/// // Banner with action
+/// Banner(
+///     title: "Missing your language?",
+///     subtitle: "Email us and we'll try to add it as soon as possible.",
+///     style: .info(),
+///     actionContent: {
+///         Button("Email us") { openEmail() }
+///     }
+/// )
+/// ```
+public struct Banner<ActionContent: View>: View {
+    /// The main banner message.
+    private let title: String
+    
+    /// Optional secondary message.
+    private let subtitle: String?
+    
+    /// Visual style of the banner.
+    private let style: BannerStyle
+    
+    /// Optional custom action view displayed at the bottom.
+    @ViewBuilder private let actionContent: () -> ActionContent
+    
+    /// Creates a banner with custom action content.
+    ///
+    /// - Parameters:
+    ///   - title: The main banner message.
+    ///   - subtitle: Optional secondary message.
+    ///   - style: Visual style (default: `.info()`).
+    ///   - actionContent: ViewBuilder for custom action content.
+    public init(
+        title: String,
+        subtitle: String? = nil,
+        style: BannerStyle = .info(),
+        @ViewBuilder actionContent: @escaping () -> ActionContent
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.style = style
+        self.actionContent = actionContent
+    }
+    
+    public var body: some View {
+        HStack(alignment: .top, spacing: style.spacing) {
+            Image(systemName: style.customIcon ?? "")
+                .font(.system(size: style.iconSize))
+                .foregroundStyle(style.iconColor)
+                .accessibilityHidden(true)
+            
+            VStack(alignment: .leading, spacing: style.verticalSpacing) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(style.titleColor)
+                    .multilineTextAlignment(.leading)
+                    .accessibilityAddTraits(.isHeader)
+
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.footnote)
+                        .foregroundStyle(style.subtitleColor)
+                        .multilineTextAlignment(.leading)
+                }
+
+                actionContent()
+                    .font(.footnote.weight(.semibold))
+                    .buttonStyle(.plain)
+                    .foregroundStyle(style.actionColor)
+                    .padding(.top, 4)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(style.padding)
+        .background(style.backgroundColor)
+        .clipShape(RoundedRectangle(cornerRadius: style.cornerRadius, style: .continuous))
+    }
+}
+
+/// Convenience initializer for banners without custom action content.
+public extension Banner where ActionContent == EmptyView {
+    /// Creates a banner without custom action content.
+    ///
+    /// - Parameters:
+    ///   - title: The main banner message.
+    ///   - subtitle: Optional secondary message.
+    ///   - style: Visual style (default: `.info()`).
+    init(
+        title: String,
+        subtitle: String? = nil,
+        style: BannerStyle = .info()
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.style = style
+        self.actionContent = { EmptyView() }
+    }
+}
+
+#Preview("Styles") {
+    VStack(spacing: 16) {
+        Banner(
+            title: "Missing your language?",
+            subtitle: "Email us and we'll try to add it as soon as possible.",
+            style: .info(),
+            actionContent: {
+                Button(action: {}) {
+                    Label("Email us", systemImage: "arrow.up.right")
+                }
+            }
+        )
+        
+        Banner(
+            title: "Warning",
+            subtitle: "This action cannot be undone.",
+            style: .warning()
+        )
+        
+        Banner(
+            title: "Success!",
+            subtitle: "Your changes have been saved.",
+            style: .success()
+        )
+        
+        Banner(
+            title: "Error",
+            subtitle: "Something went wrong.",
+            style: .error()
+        )
+    }
+    .padding()
+}

--- a/Sources/UILibrary/Components/Molecules/Banner/BannerStyle+Preset.swift
+++ b/Sources/UILibrary/Components/Molecules/Banner/BannerStyle+Preset.swift
@@ -1,0 +1,71 @@
+//
+//  BannerStyle+Preset.swift
+//  UILibrary
+//
+//  Created by Marco La Gala on 20/02/26.
+//
+
+import SwiftUI
+
+/// Common, brand-agnostic `BannerStyle` presets used by apps/design systems for quick usage.
+public extension BannerStyle {
+    /// Creates an info-style banner (blue theme).
+    /// - Parameters:
+    ///   - customIcon: Optional custom icon (default: "info.circle.fill").
+    /// - Returns: A `BannerStyle` configured for informational messages.
+    static func info(customIcon: String? = nil) -> BannerStyle {
+        BannerStyle(
+            backgroundColor: Color.blue.opacity(0.15),
+            iconColor: .blue,
+            titleColor: .primary,
+            subtitleColor: .secondary,
+            actionColor: .blue,
+            customIcon: customIcon ?? "info.circle.fill"
+        )
+    }
+    
+    /// Creates a warning-style banner (orange theme).
+    /// - Parameters:
+    ///   - customIcon: Optional custom icon (default: "exclamationmark.triangle.fill").
+    /// - Returns: A `BannerStyle` configured for warning messages.
+    static func warning(customIcon: String? = nil) -> BannerStyle {
+        BannerStyle(
+            backgroundColor: Color.orange.opacity(0.15),
+            iconColor: .orange,
+            titleColor: .primary,
+            subtitleColor: .secondary,
+            actionColor: .orange,
+            customIcon: customIcon ?? "exclamationmark.triangle.fill"
+        )
+    }
+    
+    /// Creates a success-style banner (green theme).
+    /// - Parameters:
+    ///   - customIcon: Optional custom icon (default: "checkmark.circle.fill").
+    /// - Returns: A `BannerStyle` configured for success messages.
+    static func success(customIcon: String? = nil) -> BannerStyle {
+        BannerStyle(
+            backgroundColor: Color.green.opacity(0.15),
+            iconColor: .green,
+            titleColor: .primary,
+            subtitleColor: .secondary,
+            actionColor: .green,
+            customIcon: customIcon ?? "checkmark.circle.fill"
+        )
+    }
+    
+    /// Creates an error-style banner (red theme).
+    /// - Parameters:
+    ///   - customIcon: Optional custom icon (default: "xmark.circle.fill").
+    /// - Returns: A `BannerStyle` configured for error messages.
+    static func error(customIcon: String? = nil) -> BannerStyle {
+        BannerStyle(
+            backgroundColor: Color.red.opacity(0.15),
+            iconColor: .red,
+            titleColor: .primary,
+            subtitleColor: .secondary,
+            actionColor: .red,
+            customIcon: customIcon ?? "xmark.circle.fill"
+        )
+    }
+}

--- a/Sources/UILibrary/Components/Molecules/Banner/BannerStyle.swift
+++ b/Sources/UILibrary/Components/Molecules/Banner/BannerStyle.swift
@@ -1,0 +1,86 @@
+//
+//  BannerStyle.swift
+//  UILibrary
+//
+//  Created by Marco La Gala on 20/02/26.
+//
+
+import SwiftUI
+
+/// Style contract for `Banner`.
+///
+/// Describes visual tokens used by `Banner` (background, icon, text colors, layout metrics).
+/// Immutable and brand-agnostic.
+public struct BannerStyle: Equatable, Sendable {
+    /// Background color of the banner.
+    public let backgroundColor: Color
+    
+    /// Color used for the icon.
+    public let iconColor: Color
+    
+    /// Color used for the title text.
+    public let titleColor: Color
+    
+    /// Color used for the subtitle text.
+    public let subtitleColor: Color
+    
+    /// Color used for action content (e.g., buttons, links).
+    public let actionColor: Color
+    
+    /// Optional custom icon (SF Symbol name). If nil, uses default for semantic type.
+    public let customIcon: String?
+    
+    /// Corner radius for the banner container.
+    public let cornerRadius: CGFloat
+    
+    /// Internal padding around banner content.
+    public let padding: CGFloat
+    
+    /// Size of the icon.
+    public let iconSize: CGFloat
+    
+    /// Horizontal spacing between icon and content.
+    public let spacing: CGFloat
+    
+    /// Vertical spacing between title and subtitle.
+    public let verticalSpacing: CGFloat
+    
+    /// Creates a `BannerStyle`.
+    /// - Parameters:
+    ///   - backgroundColor: Background color of the banner.
+    ///   - iconColor: Color for the icon.
+    ///   - titleColor: Color for the title text.
+    ///   - subtitleColor: Color for the subtitle text.
+    ///   - actionColor: Color for action content.
+    ///   - customIcon: Optional custom icon (SF Symbol name).
+    ///   - cornerRadius: Corner radius for the banner container (default: 12).
+    ///   - padding: Internal padding around content (default: 16).
+    ///   - iconSize: Size of the icon (default: 20).
+    ///   - spacing: Horizontal spacing between icon and content (default: 12).
+    ///   - verticalSpacing: Vertical spacing between title and subtitle (default: 4).
+    public init(
+        backgroundColor: Color,
+        iconColor: Color,
+        titleColor: Color,
+        subtitleColor: Color,
+        actionColor: Color,
+        customIcon: String? = nil,
+        cornerRadius: CGFloat = 12,
+        padding: CGFloat = 16,
+        iconSize: CGFloat = 20,
+        spacing: CGFloat = 12,
+        verticalSpacing: CGFloat = 4
+    ) {
+        self.backgroundColor = backgroundColor
+        self.iconColor = iconColor
+        self.titleColor = titleColor
+        self.subtitleColor = subtitleColor
+        self.actionColor = actionColor
+        self.customIcon = customIcon
+        self.cornerRadius = cornerRadius
+        self.padding = padding
+        self.iconSize = iconSize
+        self.spacing = spacing
+        self.verticalSpacing = verticalSpacing
+    }
+}


### PR DESCRIPTION
## Summary

Add a new **Banner** molecule component for displaying contextual informational messages with optional actions.

## Changes

### Added
- `Banner` molecule component supporting info, warning, success, and error styles
- `BannerStyle` contract with brand-agnostic visual tokens
- `BannerStyle+Preset` with semantic presets (`.info()`, `.warning()`, `.success()`, `.error()`)
- Support for optional subtitle and custom action content via ViewBuilder
- Comprehensive previews demonstrating all style variants

### Updated
- `README.md` - Added Banner to Molecules section
- `CHANGELOG.md` - Documented Banner addition
- `JOURNAL.md` - Added entry with rationale

## Architecture Compliance

✅ **Atomic Design**: Molecule layer (combines icon, text, and action content)  
✅ **Style Injection**: All visual tokens provided via `BannerStyle`  
✅ **Brand-agnostic**: No hardcoded brand tokens  
✅ **No Business Logic**: Purely presentational  
✅ **Documentation**: Complete SwiftDoc comments  
✅ **Immutable Style**: `BannerStyle` is `Equatable` and `Sendable`

## Testing

- ✅ Build passes (`swift build --build-system swiftbuild`)
- ✅ Tests pass (`swift test --build-system swiftbuild`)
- ✅ Previews compile for all style variants

## Example Usage

```swift
// Simple banner
Banner(
    subtitle: "Your changes have been saved.",
    style: .success()
)

// Banner with action
Banner(
    title: "Missing your language?",
    subtitle: "Email us and we'll try to add it as soon as possible.",
    style: .info(),
    actionContent: {
        Button("Email us") { openEmail() }
    }
)
```

## Checklist

- [x] Code in correct folder (Molecules/Banner/)
- [x] In-source SwiftDoc documentation
- [x] README.md updated
- [x] CHANGELOG.md updated
- [x] JOURNAL.md entry added
- [x] Previews compile
- [x] No brand tokens
- [x] Style struct immutable
- [x] All public APIs documented
- [x] Build passes
- [x] Tests pass